### PR TITLE
Improvement/#22454 Investigate if the way we launch the mcp servers is correct

### DIFF
--- a/packaging/rpm/Makefile
+++ b/packaging/rpm/Makefile
@@ -45,6 +45,7 @@ srpm: build_prepare
 rpm: srpm
 	/usr/bin/mock \
 		-r $(MOCK_CONFIG) \
+		--enable-network \
 		--define "__version $(VERSION)"\
 		--define "__release $(BUILD_NUMBER)"\
 		--define "__pyenv_root $(PYENV_ROOT)" \

--- a/packaging/rpm/redborder-agents_requirements.txt
+++ b/packaging/rpm/redborder-agents_requirements.txt
@@ -337,7 +337,7 @@ networkx==3.5
     # via pyvis
 nodeenv==1.9.1
     # via pyright
-numpy==2.3.2
+numpy==1.26.4
     # via
     #   chroma-hnswlib
     #   chromadb

--- a/packaging/rpm/redborder-pythonpyenv.spec
+++ b/packaging/rpm/redborder-pythonpyenv.spec
@@ -2,9 +2,13 @@
 
 %global pyenv_root %{__pyenv_root}
 %global python_version %{__python_version}
+
+# =====================
+# redborder-agents
+# =====================
 %global redborder_agents_dir /opt/redborder-agents
 %global redborder_agents_venv_path %{redborder_agents_dir}/venv
-%global redborder_agents_webui_venv_path %{redborder_agents_dir}/src/redborder_agents/servers/webui/venv
+%global redborder_agents_webui_venv_path %{redborder_agents_dir}/src/redborder_agents/servers/webui/.venv
 
 %global __provides_exclude ^python3$|libpython3\.11\.so\.1\.0.*|libpython3\.so.*|libsqlite3.*
 %global __provides_exclude_from %{pyenv_root}/.*|%{redborder_agents_dir}/.*
@@ -26,8 +30,7 @@ BuildRequires: gcc, gcc-c++, make, zlib-devel, bzip2-devel, readline-devel, sqli
 Requires: bash, openblas-devel
 
 %description
-This package installs pyenv into %{pyenv_root}, Python %{python_version}, 
-and two virtualenvs: one for redborder-agents and another for the webui MCP server.
+This package installs pyenv into %{pyenv_root}, Python %{python_version}, and two virtualenvs: one for redborder-agents and another for the webui MCP server.
 
 %prep
 # No source to unpack
@@ -91,7 +94,7 @@ $PYTHON_BIN -m venv %{redborder_agents_webui_venv_path}
 %{redborder_agents_webui_venv_path}/bin/pip install --no-deps -r $RPM_SOURCE_DIR/mcp-server-webui_requirements.txt
 
 # Verificar MCP
-%{redborder_agents_webui_venv_path}/bin/python -c "import mcp; print('MCP:', mcp.__version__)"
+%{redborder_agents_webui_venv_path}/bin/python -c "import importlib.metadata; print('MCP:', importlib.metadata.version('mcp'))"
 
 %install
 mkdir -p %{buildroot}%{pyenv_root}
@@ -106,7 +109,7 @@ cp -a %{redborder_agents_dir}/. %{buildroot}%{redborder_agents_dir}/
 
 %changelog
 * Wed Sep 10 2025 Rafael Gómez <rgomez@redborder.com>
-- Improve performance of RPM builiding
+- Improve performance of RPM builiding and split up redborder-agents venv
 
 * Sat Aug 9 2025 manegron <manegron@email>
 - Excluir algunas librerias internas como provides 

--- a/packaging/rpm/redborder-pythonpyenv.spec
+++ b/packaging/rpm/redborder-pythonpyenv.spec
@@ -25,8 +25,7 @@ ExclusiveArch: x86_64
 Source0: redborder-agents_requirements.txt
 Source1: mcp-server-webui_requirements.txt
 
-BuildRequires: gcc, gcc-c++, make, zlib-devel, bzip2-devel, readline-devel, sqlite-devel, openssl-devel, xz-devel, libffi-devel, git, curl, autoconf, automake, libtool, gcc-gfortran, autoconf, openblas-devel
-
+BuildRequires: gcc, gcc-c++, make, zlib-devel, bzip2-devel, readline-devel, sqlite-devel, openssl-devel, xz-devel, libffi-devel, git, curl, autoconf, automake, libtool, gcc-gfortran, openblas-devel
 Requires: bash, openblas-devel
 
 %description
@@ -58,58 +57,35 @@ cd ..
 
 # Exportar variables de compilación
 export CPPFLAGS="-I$SQLITE_PREFIX/include"
-export LDFLAGS="-L$SQLITE_PREFIX/lib"
+export LDFLAGS="-L$SQLITE_PREFIX/lib -Wl,-rpath,$SQLITE_PREFIX/lib"
 export LD_RUN_PATH="$SQLITE_PREFIX/lib"
 export PKG_CONFIG_PATH="$SQLITE_PREFIX/lib/pkgconfig"
+export CONFIGURE_OPTS="--with-ensurepip=install --enable-loadable-sqlite-extensions"
 export MAKE_OPTS="-j$(nproc)"
 
-# Forzar rpath para encontrar libsqlite en tiempo de ejecución
-export CONFIGURE_OPTS="--with-ensurepip=install --enable-loadable-sqlite-extensions"
-
-# Inicializar pyenv y compilar Python
+# Compilar Python con pyenv
 eval "$(%{pyenv_root}/bin/pyenv init -)"
-env \
-  CPPFLAGS="$CPPFLAGS" \
-  LDFLAGS="$LDFLAGS -Wl,-rpath,$SQLITE_PREFIX/lib" \
-  PKG_CONFIG_PATH="$PKG_CONFIG_PATH" \
-  CONFIGURE_OPTS="$CONFIGURE_OPTS" \
-  MAKE_OPTS="$MAKE_OPTS" \
-  %{pyenv_root}/bin/pyenv install %{python_version}
-
-# Usar la versión compilada
+%{pyenv_root}/bin/pyenv install %{python_version}
 %{pyenv_root}/bin/pyenv global %{python_version}
-
 PYTHON_BIN=%{pyenv_root}/versions/%{python_version}/bin/python3
 
 # Preparar entorno virtual
-$PYTHON_BIN -m ensurepip
-$PYTHON_BIN -m pip install --upgrade pip setuptools virtualenv
-
-# Create redborder-agents venv and install dependencies
+$PYTHON_BIN -m pip install --upgrade pip setuptools virtualenv wheel
 mkdir -p %{redborder_agents_dir}
+$PYTHON_BIN -m venv %{redborder_agents_venv_path}
 
-# Create reborder-agents venv
-$PYTHON_BIN -m virtualenv %{redborder_agents_venv_path}
-
-# Activate venv and install packages
-. %{redborder_agents_venv_path}/bin/activate
-
-%{redborder_agents_venv_path}/bin/pip install --upgrade pip setuptools
-
-# Install from source to avoid problems
-%{redborder_agents_venv_path}/bin/pip install --no-binary=:all: numpy scipy
+# Instalar dependencias
+%{redborder_agents_venv_path}/bin/pip install --upgrade pip setuptools wheel
+%{redborder_agents_venv_path}/bin/pip install numpy scipy
 
 # Install redborder-agents dependencies
-%{redborder_agents_venv_path}/bin/pip install -r $RPM_SOURCE_DIR/redborder-agents_requirements.txt
-
+%{redborder_agents_venv_path}/bin/pip install --no-deps -r $RPM_SOURCE_DIR/redborder-agents_requirements.txt
 # Install webui mcp server dependencies
-%{redborder_agents_venv_path}/bin/pip install -r $RPM_SOURCE_DIR/mcp-server-webui_requirements.txt
+%{redborder_agents_venv_path}/bin/pip install --no-deps -r $RPM_SOURCE_DIR/mcp-server-webui_requirements.txt
 
 # Verificar SQLite y crewai
-%{redborder_agents_venv_path}/bin/python -c "import sqlite3; print(sqlite3.sqlite_version)"
-%{redborder_agents_venv_path}/bin/python -c "import crewai; print('CrewAI version:', crewai.__version__)"
-
-deactivate
+%{redborder_agents_venv_path}/bin/python -c "import sqlite3; print('SQLite:', sqlite3.sqlite_version)"
+%{redborder_agents_venv_path}/bin/python -c "import crewai; print('CrewAI:', crewai.__version__)"
 
 %install
 mkdir -p %{buildroot}%{pyenv_root}
@@ -122,6 +98,9 @@ cp -a %{redborder_agents_dir}/. %{buildroot}%{redborder_agents_dir}/
 %{redborder_agents_venv_path}
 
 %changelog
+* Wed Sep 10 2025 Rafael Gómez <rgomez@redborder.com>
+- Improve performance of RPM builiding
+
 * Sat Aug 9 2025 manegron <manegron@email>
 - Excluir algunas librerias internas como provides 
 

--- a/packaging/rpm/redborder-pythonpyenv.spec
+++ b/packaging/rpm/redborder-pythonpyenv.spec
@@ -4,17 +4,14 @@
 %global python_version %{__python_version}
 %global redborder_agents_dir /opt/redborder-agents
 %global redborder_agents_venv_path %{redborder_agents_dir}/venv
+%global redborder_agents_webui_venv_path %{redborder_agents_dir}/src/redborder_agents/servers/webui/venv
 
 %global __provides_exclude ^python3$|libpython3\.11\.so\.1\.0.*|libpython3\.so.*|libsqlite3.*
-
 %global __provides_exclude_from %{pyenv_root}/.*|%{redborder_agents_dir}/.*
-
 %global __requires_exclude ^python3$
-
 %global __requires_exclude_from %{pyenv_root}/.*|%{redborder_agents_dir}/.*
-
 %undefine __brp_mangle_shebangs
- 
+
 Name: redborder-pythonpyenv
 Version: %{__version}
 Release: %{__release}%{?dist}
@@ -29,7 +26,8 @@ BuildRequires: gcc, gcc-c++, make, zlib-devel, bzip2-devel, readline-devel, sqli
 Requires: bash, openblas-devel
 
 %description
-This package installs pyenv into %{pyenv_root}, Python %{python_version}, and a virtualenv with crewai and dependencies.
+This package installs pyenv into %{pyenv_root}, Python %{python_version}, 
+and two virtualenvs: one for redborder-agents and another for the webui MCP server.
 
 %prep
 # No source to unpack
@@ -70,22 +68,30 @@ eval "$(%{pyenv_root}/bin/pyenv init -)"
 PYTHON_BIN=%{pyenv_root}/versions/%{python_version}/bin/python3
 
 # Preparar entorno virtual
-$PYTHON_BIN -m pip install --upgrade pip setuptools virtualenv wheel
+$PYTHON_BIN -m pip install --upgrade pip setuptools virtualenv
+
+# =====================
+# VENV redborder-agents
+# =====================
 mkdir -p %{redborder_agents_dir}
 $PYTHON_BIN -m venv %{redborder_agents_venv_path}
-
-# Instalar dependencias
-%{redborder_agents_venv_path}/bin/pip install --upgrade pip setuptools wheel
-%{redborder_agents_venv_path}/bin/pip install numpy scipy
-
-# Install redborder-agents dependencies
+%{redborder_agents_venv_path}/bin/pip install --upgrade pip setuptools
 %{redborder_agents_venv_path}/bin/pip install --no-deps -r $RPM_SOURCE_DIR/redborder-agents_requirements.txt
-# Install webui mcp server dependencies
-%{redborder_agents_venv_path}/bin/pip install --no-deps -r $RPM_SOURCE_DIR/mcp-server-webui_requirements.txt
 
 # Verificar SQLite y crewai
 %{redborder_agents_venv_path}/bin/python -c "import sqlite3; print('SQLite:', sqlite3.sqlite_version)"
 %{redborder_agents_venv_path}/bin/python -c "import crewai; print('CrewAI:', crewai.__version__)"
+
+# =====================
+# VENV webui MCP server
+# =====================
+mkdir -p $(dirname %{redborder_agents_webui_venv_path})
+$PYTHON_BIN -m venv %{redborder_agents_webui_venv_path}
+%{redborder_agents_webui_venv_path}/bin/pip install --upgrade pip setuptools
+%{redborder_agents_webui_venv_path}/bin/pip install --no-deps -r $RPM_SOURCE_DIR/mcp-server-webui_requirements.txt
+
+# Verificar MCP
+%{redborder_agents_webui_venv_path}/bin/python -c "import mcp; print('MCP:', mcp.__version__)"
 
 %install
 mkdir -p %{buildroot}%{pyenv_root}
@@ -96,6 +102,7 @@ cp -a %{redborder_agents_dir}/. %{buildroot}%{redborder_agents_dir}/
 %files
 %{pyenv_root}
 %{redborder_agents_venv_path}
+%{redborder_agents_webui_venv_path}
 
 %changelog
 * Wed Sep 10 2025 Rafael Gómez <rgomez@redborder.com>


### PR DESCRIPTION
## Related issue in RedMine

- [Associated Redmine task](https://redmine.redborder.lan/issues/22454)

## Description

- Split up `redborder-agents` venv.
  - **redborder-agents**: Located at `/opt/redborder-agents/venv`.
  - **mcp-webui-sever**: Located at `/opt/redborder-agents/src/redborder_agents/servers/webui/.venv`.
- Improving the performance of RPM building from > 50 min to ~11 minutes.

```cmd
Finish: rpmbuild redborder-pythonpyenv-0.1.0-1.el9.rb.src.rpm
Finish: build phase for redborder-pythonpyenv-0.1.0-1.el9.rb.src.rpm
INFO: Done(pkgs/redborder-pythonpyenv-0.1.0-1.el9.rb.src.rpm) Config(default) 11 minutes 2 seconds
INFO: Results and/or logs in: pkgs
INFO: Cleaning up build root ('cleanup_on_success=True')
Start: clean chroot
Finish: clean chroot
Finish: run
======= Binary RPMs now available in pkgs =======
make[1]: Leaving directory '/home/rgomez/redborder/redborder-pythonpyenv/packaging/rpm'
```